### PR TITLE
spec :forms can yield ::invalidity early

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,19 +7,20 @@
 
   :dependencies [[org.clojure/clojure "1.10.1"]]
 
-  :profiles {:test {:dependencies [[org.clojure/test.check "0.9.0"]
-                                   [org.clojure/clojurescript "1.10.758"]]
-                    :plugins [[lein-cljsbuild "1.1.8" :exclusions [[org.clojure/clojure]]]
-                              [lein-doo "0.1.10"]
-                              [lein-figwheel "0.5.20"]]
+  :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]
+                                  [org.clojure/clojurescript "1.10.758"]]
+                   :plugins [[lein-cljsbuild "1.1.8" :exclusions [[org.clojure/clojure]]]
+                             [lein-doo "0.1.10"]
+                             [lein-figwheel "0.5.20"]
+                             [lein-cljfmt "0.7.0"]]
+                   :cljfmt {:remove-multiple-non-indenting-spaces? true}
+                   :cljsbuild {:builds [{:id "test"
+                                         :source-paths ["src" "test"]
+                                         :compiler {:main exoscale.coax.cljs-test-runner
+                                                    :optimizations :none
+                                                    :output-to "resources/public/cljs/tests/all-tests.js"}}]}
 
-                    :cljsbuild {:builds [{:id "test"
-                                          :source-paths ["src" "test"]
-                                          :compiler {:main exoscale.coax.cljs-test-runner
-                                                     :optimizations :none
-                                                     :output-to "resources/public/cljs/tests/all-tests.js"}}]}
-
-                    :doo {:build "test"}}}
+                   :doo {:build "test"}}}
   :pedantic? :warn
 
   :release-tasks [["vcs" "assert-committed"]

--- a/src/exoscale/coax.cljc
+++ b/src/exoscale/coax.cljc
@@ -42,9 +42,14 @@
         (reduce-kv (fn [m k v]
                      (assoc m
                             k
-                            (coerce (or (keys-mapping k) k)
-                                    v
-                                    opts)))
+                            (let [s (or (keys-mapping k) k)]
+                              ;; only try to coerce registered specs
+                              ;; from mapping
+                              (if (qualified-ident? s)
+                                (coerce s
+                                        v
+                                        opts)
+                                v))))
                    (empty x)
                    x)
         :exoscale.coax/invalid))))
@@ -112,7 +117,9 @@
                 ;; defaults do not overwrite coerced values
                 (into m
                       (keep (fn [[spec v]]
-                              (let [new-val (coerce spec v opts)]
+                              (let [new-val (if (qualified-ident? spec)
+                                              (coerce spec v opts)
+                                              v)]
                                 ;; new-val doesn't match default, keep it
                                 (when-not (= (get x spec) new-val)
                                   [spec new-val]))))
@@ -287,6 +294,18 @@
     (coerce-fn x opts)
     x))
 
+(s/def ::opts map?)
+(s/def ::symbolic-spec (s/or :spec-sym symbol?
+                             :spec-sym-form (s/cat :h symbol?
+                                                   :more (s/* any?))))
+(s/def ::reg-spec qualified-keyword?)
+(s/def ::spec (s/or :reg-spec ::reg-spec
+                    :symbolic-spec ::symbolic-spec))
+
+(s/fdef coerce
+  :args (s/cat :spec ::spec
+               :x any?
+               :opts (s/? (s/nilable ::opts))))
 (defn coerce
   "Coerce a value `x` using coercer `k`. This function will first try to
   use a coercer from the registry, otherwise it will try to infer a
@@ -299,33 +318,43 @@
        x
        x'))))
 
+(s/fdef coerce!
+  :args (s/cat :spec ::reg-spec
+               :x any?
+               :opts (s/? (s/nilable ::opts))))
 (defn coerce!
   "Like coerce, but will call s/assert on the result, making it throw an
-  error if value doesn't comply after coercion."
+  error if value doesn't comply after coercion. Only works with
+  registered specs"
   ([spec x] (coerce! spec x {}))
   ([spec x opts]
-   (let [coerced (coerce* spec x opts)]
-     (if (or (= :exoscale.coax/invalid coerced)
-             (and (qualified-keyword? spec)
-                  (not (s/valid? spec coerced))))
+   (let [coerced (coerce spec x opts)]
+     (if (s/valid? spec coerced)
+       coerced
        (throw (ex-info "Invalid coerced value"
                        {:type :exoscale.coax/invalid-coerced-value
-                        :value x
-                        :spec spec}))
-       coerced))))
+                        :val x
+                        :coerced coerced
+                        :spec spec}))))))
 
+(s/fdef conform
+  :args (s/cat :spec ::reg-spec
+               :x any?
+               :opts (s/? (s/nilable ::opts))))
 (defn conform
-  "Like coerce, and will call s/conform on the result."
+  "Like coerce, and will call s/conform on the result. Only works with
+  registered specs"
   ([spec x] (conform spec x {}))
   ([spec x opts]
    (s/conform spec (coerce spec x opts))))
 
-(defn ^:no-doc def-impl [k coerce-fn]
+(defn ^:no-doc def-impl
+  [k coerce-fn]
   (swap! registry-ref assoc-in [:exoscale.coax/idents k] coerce-fn)
   k)
 
 (s/fdef def
-  :args (s/cat :k qualified-keyword?
+  :args (s/cat :k ::reg-spec
                :coercion any?)
   :ret qualified-keyword?)
 (defmacro def
@@ -334,6 +363,9 @@
   [k coercion]
   `(def-impl '~k ~coercion))
 
+(s/fdef coerce-structure
+  :args (s/cat :x any?
+               :opts (s/? (s/nilable ::opts))))
 (defn coerce-structure
   "Recursively coerce map values on a structure."
   ([x] (coerce-structure x {}))

--- a/src/exoscale/coax/coercer.cljc
+++ b/src/exoscale/coax/coercer.cljc
@@ -35,11 +35,11 @@
   (invalid-on-throw!
    (cond (string? x)
          #?(:clj  (case x
-                    "##-Inf"    ##-Inf
-                    "##Inf"     ##Inf
-                    "##NaN"     ##NaN
-                    "NaN"       ##NaN
-                    "Infinity"  ##Inf
+                    "##-Inf" ##-Inf
+                    "##Inf" ##Inf
+                    "##NaN" ##NaN
+                    "NaN" ##NaN
+                    "Infinity" ##Inf
                     "-Infinity" ##-Inf
                     (Double/parseDouble x))
             :cljs (if (= "NaN" x)
@@ -67,8 +67,8 @@
     x
     (string? x)
     (invalid-on-throw!
-      #?(:clj  (UUID/fromString x)
-         :cljs (uuid x)))
+     #?(:clj (UUID/fromString x)
+        :cljs (uuid x)))
     :else :exoscale.coax/invalid))
 
 (defn to-inst
@@ -78,8 +78,8 @@
     x
     (string? x)
     (invalid-on-throw!
-      #?(:clj (clojure.instant/read-instant-date x)
-         :cljs (cljs.reader/parse-timestamp x)))
+     #?(:clj (clojure.instant/read-instant-date x)
+        :cljs (cljs.reader/parse-timestamp x)))
     :else :exoscale.coax/invalid))
 
 (defn to-boolean
@@ -133,8 +133,6 @@
                (str/ends-with? x "M"))
         (bigdec (subs x 0 (dec (count x))))
         (bigdec x)))))
-
-(to-decimal "42.42" nil)
 
 #?(:clj
    (defn to-uri

--- a/test/exoscale/coax_test.cljc
+++ b/test/exoscale/coax_test.cljc
@@ -2,17 +2,17 @@
   #?(:cljs (:require-macros [cljs.test :refer [deftest testing is are run-tests]]
                             [exoscale.coax :as sc]))
   (:require
-    #?(:clj [clojure.test :refer [deftest testing is are]])
-    [clojure.spec.alpha :as s]
-    [clojure.string :as str]
-    [clojure.test.check :as tc]
-    [clojure.test.check.generators]
-    [clojure.test.check.properties :as prop]
-    [clojure.spec.test.alpha :as st]
-    #?(:clj [clojure.test.check.clojure-test :refer [defspec]])
-    #?(:cljs [clojure.test.check.clojure-test :refer-macros [defspec]])
-    [exoscale.coax :as sc]
-    [exoscale.coax.coercer :as c])
+   #?(:clj [clojure.test :refer [deftest testing is are]])
+   [clojure.spec.alpha :as s]
+   [clojure.string :as str]
+   [clojure.test.check :as tc]
+   [clojure.test.check.generators]
+   [clojure.test.check.properties :as prop]
+   [clojure.spec.test.alpha :as st]
+   #?(:clj [clojure.test.check.clojure-test :refer [defspec]])
+   #?(:cljs [clojure.test.check.clojure-test :refer-macros [defspec]])
+   [exoscale.coax :as sc]
+   [exoscale.coax.coercer :as c])
   #?(:clj (:import (java.net URI))))
 
 #?(:clj (st/instrument))
@@ -118,7 +118,13 @@
 (deftest test-coerce!
   (is (= (sc/coerce! ::infer-int "123") 123))
   (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                        #"Invalid coerced value" (sc/coerce! ::infer-int "abc"))))
+                        #"Invalid coerced value" (sc/coerce! ::infer-int "abc")))
+
+  (is (= (sc/coerce! `int? "123") 123))
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                        #"Invalid coerced value" (sc/coerce! `(s/coll-of string?) 1)))
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                        #"Invalid coerced value" (sc/coerce! `(s/coll-of ::int-set) ""))))
 
 (deftest test-conform
   (is (= (sc/conform ::or-example "true") [:bool true])))
@@ -192,7 +198,7 @@
     `(s/or :str string? :kw keyword? :number? number?) :asdf :asdf
     `(s/or :str string? :kw keyword? :number? number?) "asdf" "asdf"
     `(s/or :kw keyword? :str string? :number? number?) "asdf" "asdf"
-    `(s/or :number? number? :kw keyword? ) "1" 1
+    `(s/or :number? number? :kw keyword?) "1" 1
     `(s/or :number? number?) "1" 1
     `(s/or :number? number? :kw keyword? :str string?) "1" "1"
     `(s/or :number? number? :kw keyword? :str string?) 1 1
@@ -203,7 +209,6 @@
 
 (def test-gens
   {`inst? (s/gen (s/inst-in #inst "1980" #inst "9999"))})
-
 
 #?(:cljs
    (defn ->js [var-name]
@@ -265,51 +270,51 @@
 
 (deftest test-coerce-structure
   (is (= (sc/coerce-structure {::some-coercion "321"
-                               ::not-defined   "bla"
-                               :sub            {::infer-int "42"}})
+                               ::not-defined "bla"
+                               :sub {::infer-int "42"}})
          {::some-coercion 321
-          ::not-defined   "bla"
-          :sub            {::infer-int 42}}))
+          ::not-defined "bla"
+          :sub {::infer-int 42}}))
   (is (= (sc/coerce-structure {::some-coercion "321"
-                               ::not-defined   "bla"
-                               :unqualified    12
-                               :sub            {::infer-int "42"}}
-           {::sc/idents {::not-defined `keyword?}})
+                               ::not-defined "bla"
+                               :unqualified 12
+                               :sub {::infer-int "42"}}
+                              {::sc/idents {::not-defined `keyword?}})
          {::some-coercion 321
-          ::not-defined   :bla
-          :unqualified    12
-          :sub            {::infer-int 42}}))
+          ::not-defined :bla
+          :unqualified 12
+          :sub {::infer-int 42}}))
   (is (= (sc/coerce-structure {::or-example "321"}
-           {::sc/op sc/conform})
+                              {::sc/op sc/conform})
          {::or-example [:int 321]})))
 
 (s/def ::bool boolean?)
 (s/def ::simple-keys (s/keys :req [::infer-int]
-                       :opt [::bool]))
+                             :opt [::bool]))
 (s/def ::nested-keys (s/keys :req [::infer-form ::simple-keys]
-                       :req-un [::bool]))
+                             :req-un [::bool]))
 
 (deftest test-coerce-keys
   (is (= {::infer-int 123}
          (sc/coerce ::simple-keys {::infer-int "123"})))
-  (is (= {::infer-form  [1 2 3]
+  (is (= {::infer-form [1 2 3]
           ::simple-keys {::infer-int 456
-                         ::bool      true}
-          :bool         true}
-         (sc/coerce ::nested-keys {::infer-form  ["1" "2" "3"]
+                         ::bool true}
+          :bool true}
+         (sc/coerce ::nested-keys {::infer-form ["1" "2" "3"]
                                    ::simple-keys {::infer-int "456"
-                                                  ::bool      "true"}
-                                   :bool         "true"})))
+                                                  ::bool "true"}
+                                   :bool "true"})))
   (is (= "garbage" (sc/coerce ::simple-keys "garbage"))))
 
 (s/def ::head double?)
 (s/def ::body int?)
-(s/def ::arm  int?)
-(s/def ::leg  double?)
+(s/def ::arm int?)
+(s/def ::leg double?)
 (s/def ::arms (s/coll-of ::arm))
 (s/def ::legs (s/coll-of ::leg))
 (s/def ::name string?)
-(s/def ::animal (s/keys :req    [::head ::body ::arms ::legs]
+(s/def ::animal (s/keys :req [::head ::body ::arms ::legs]
                         :opt-un [::name ::id]))
 
 (deftest test-coerce-with-registry-overrides
@@ -396,3 +401,8 @@
 (deftest test-gigo
   (is (= (sc/coerce `(some-unknown-form string?) 1) 1))
   (is (= (sc/coerce `(some-unknown-form) 1) 1)))
+
+(deftest invalidity-test
+  (is (= :exoscale.coax/invalid (sc/coerce* `int? [] {})))
+  (is (= :exoscale.coax/invalid (sc/coerce* `(s/coll-of int?) 1 {})))
+  (is (= :exoscale.coax/invalid (sc/coerce* ::int-set "" {}))))

--- a/test/exoscale/coax_test.cljc
+++ b/test/exoscale/coax_test.cljc
@@ -118,13 +118,7 @@
 (deftest test-coerce!
   (is (= (sc/coerce! ::infer-int "123") 123))
   (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                        #"Invalid coerced value" (sc/coerce! ::infer-int "abc")))
-
-  (is (= (sc/coerce! `int? "123") 123))
-  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                        #"Invalid coerced value" (sc/coerce! `(s/coll-of string?) 1)))
-  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
-                        #"Invalid coerced value" (sc/coerce! `(s/coll-of ::int-set) ""))))
+                        #"Invalid coerced value" (sc/coerce! ::infer-int "abc"))))
 
 (deftest test-conform
   (is (= (sc/conform ::or-example "true") [:bool true])))
@@ -379,6 +373,14 @@
       "Coerce new vals appropriately")
   (is (= {:foo 1 :bar "1" :c {:a 2}}
          (sc/coerce ::merge {:foo 1 :bar "1" :c {:a 2}}))
+      "Leave out ok vals")
+
+  (s/def ::merge2 (s/merge (s/keys :req [::foo])
+                           ::unqualified))
+
+  (is (= {::foo 1 :bar "1" :c {:a 2}
+          :foo 1}
+         (sc/coerce ::merge2 {::foo "1" :foo "1" :bar "1" :c {:a 2}}))
       "Leave out ok vals")
 
   (is (= "garbage" (sc/coerce ::merge "garbage"))


### PR DESCRIPTION
This should fix #7 and another edge case with `coerce!` . 

This also remove the explain-data from the exception thrown, it's the responsibility of the use to do that (like with spec)