### PR TITLE
Add coercer resolution cache ("on" by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,25 @@ Examples from predicate to coerced value:
 (c/coerce-structure {::number "42"} {::c/op c/conform})
 ```
 
+## Caching
+
+Coax applies caching of coercers function to cut the cost of walking
+specs and generating coercers per call, it makes the coercion process
+orders of magnitude faster once cache (depends on what the coercion
+does of course). It is `on` by default. The cache is under
+`exoscale.coax/coercer-cache`, it's just an atom holding a map of
+`[spec, options] -> coercer`. In most case you should have to care
+about this, for instance when you define static coercers via
+`coax/def` we'll make sure the cache is updated accordingly, but
+during development you might need to be aware of the existence of that
+cache (ex if you defined a bugged coercer, or while doing repl dev).
+
+In any case you can turn off the cache by passing
+`:exoscale.coax/cache? false` to the options of
+coerce/conform/coerce-structure, alternatively you can manually fiddle
+with the cache under `exoscale.coax/coercer-cache`, for instance via
+`(reset! exoscale.coax/coercer-cache {})`.
+
 ## License
 
 * License Copyright © 2020 Exoscale - Distributed under ISC License

--- a/src/exoscale/coax.cljc
+++ b/src/exoscale/coax.cljc
@@ -300,11 +300,9 @@
 (defn cached-coerce-fn
   [spec opts]
   (let [k [spec opts]]
-    (if (:exoscale.coax/force-cache-update? opts)
-      (update-cache! coercer-cache k (coerce-fn* spec opts))
-      (if-let [e (find @coercer-cache k)]
-        (val e)
-        (update-cache! coercer-cache k (coerce-fn* spec opts))))))
+    (if-let [e (find @coercer-cache k)]
+      (val e)
+      (update-cache! coercer-cache k (coerce-fn* spec opts)))))
 
 (defn coerce-fn
   [spec opts]

--- a/src/exoscale/coax.cljc
+++ b/src/exoscale/coax.cljc
@@ -292,14 +292,19 @@
 
 (def coercer-cache (atom {}))
 
+(defn update-cache!
+  [cache k coercer]
+  (swap! cache assoc k coercer)
+  coercer)
+
 (defn cached-coerce-fn
   [spec opts]
   (let [k [spec opts]]
-    (if-let [e (find @coercer-cache [spec opts])]
-      (val e)
-      (let [ret (coerce-fn* spec opts)]
-        (swap! coercer-cache assoc k ret)
-        ret))))
+    (if (:exoscale.coax/force-cache-update? opts)
+      (update-cache! coercer-cache k (coerce-fn* spec opts))
+      (if-let [e (find @coercer-cache k)]
+        (val e)
+        (update-cache! coercer-cache k (coerce-fn* spec opts))))))
 
 (defn coerce-fn
   [spec opts]

--- a/src/exoscale/coax.cljc
+++ b/src/exoscale/coax.cljc
@@ -379,6 +379,15 @@
 (defn ^:no-doc def-impl
   [k coerce-fn]
   (swap! registry-ref assoc-in [:exoscale.coax/idents k] coerce-fn)
+  ;; ensure all cache entries for that key are cleared
+  (swap! coercer-cache
+         (fn [cache]
+           (reduce-kv (fn [cache [spec _opts :as cache-key] coercer]
+                        (cond-> cache
+                          (not (= k spec))
+                          (assoc cache-key coercer)))
+                      {}
+                      cache)))
   k)
 
 (s/fdef def

--- a/test/exoscale/coax_test.cljc
+++ b/test/exoscale/coax_test.cljc
@@ -410,3 +410,15 @@
   (is (= :exoscale.coax/invalid (sc/coerce* `int? [] {})))
   (is (= :exoscale.coax/invalid (sc/coerce* `(s/coll-of int?) 1 {})))
   (is (= :exoscale.coax/invalid (sc/coerce* ::int-set "" {}))))
+
+
+(deftest test-caching
+  (s/def ::bs (s/keys :req [::bool]))
+  (is (= false (sc/coerce ::bool "false")))
+  (is (= false (::bool (sc/coerce ::bs {::bool "false"}))))
+  (is (= false (sc/coerce ::bool
+                          "false"
+                          {:exoscale.coax/cache? false})))
+  (is (= false (::bool (sc/coerce ::bs
+                                  {::bool "false"}
+                                  {:exoscale.coax/cache? false})))))


### PR DESCRIPTION
This speeds up dramatically coercing, since no spec walking/coercer resolution has to happen more than once per spec+opts. It turns a coerce call into coercer lookup in atom and a single call to (coercer x opts). 

I added `exoscale.coax/cache?` (defaults to true). 

By default cache is on. When cache is on you can force cache update via the mentioned option or just skip the cache. 
