### PR TITLE
Fix set coerce bug

### DIFF
--- a/src/exoscale/coax.cljc
+++ b/src/exoscale/coax.cljc
@@ -56,7 +56,7 @@
 
 (defn gen-coerce-coll-of [[_ spec & {:as _opts :keys [kind]}]]
   (fn [x opts]
-    (if (sequential? x)
+    (if (coll? x)
       ;; either we have a `:kind` and coerce to that, or we
       ;; just `empty` the original
       (let [xs (into (condp = kind
@@ -84,7 +84,7 @@
 
 (defn gen-coerce-tuple [[_ & specs]]
   (fn [x opts]
-    (if (sequential? x)
+    (if (coll? x)
       (mapv #(coerce %1 %2 opts)
             specs
             x)

--- a/src/exoscale/coax.cljc
+++ b/src/exoscale/coax.cljc
@@ -84,7 +84,7 @@
 
 (defn gen-coerce-tuple [[_ & specs]]
   (fn [x opts]
-    (if (coll? x)
+    (if (sequential? x)
       (mapv #(coerce %1 %2 opts)
             specs
             x)

--- a/test/exoscale/coax_test.cljc
+++ b/test/exoscale/coax_test.cljc
@@ -364,7 +364,6 @@
 
 (deftest test-tuple
   (is (= [0 "" 1] (sc/coerce ::tuple ["0" nil "1"])))
-  (is (= #{0 "" 1} (sc/coerce ::tuple ["0" nil "1"])))
   (is (= "garbage" (sc/coerce ::tuple "garbage"))))
 
 (deftest test-merge

--- a/test/exoscale/coax_test.cljc
+++ b/test/exoscale/coax_test.cljc
@@ -174,6 +174,7 @@
     `(s/coll-of int?) ["11" "foo" "42"] [11 "foo" 42]
     `(s/coll-of int? :kind list?) ["11" "foo" "42"] '(11 "foo" 42)
     `(s/coll-of int? :kind set?) ["11" "foo" "42"] #{11 "foo" 42}
+    `(s/coll-of int? :kind set?) #{"11" "foo" "42"} #{11 "foo" 42}
     `(s/coll-of int? :kind vector?) '("11" "foo" "42") [11 "foo" 42]
     `(s/every int?) ["11" "31" "42"] [11 31 42]
 
@@ -363,6 +364,7 @@
 
 (deftest test-tuple
   (is (= [0 "" 1] (sc/coerce ::tuple ["0" nil "1"])))
+  (is (= #{0 "" 1} (sc/coerce ::tuple ["0" nil "1"])))
   (is (= "garbage" (sc/coerce ::tuple "garbage"))))
 
 (deftest test-merge


### PR DESCRIPTION
without this (s/coll-of keyword? :kind set?) on #{"a"} would fail to trigger coercion